### PR TITLE
Update to latest NSB.Metrics and NSB.Core

### DIFF
--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/IntegrationTests.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/IntegrationTests.cs
@@ -36,7 +36,7 @@ public class IntegrationTests
             .ConfigureAwait(false);
 
         ManualResetEvent.WaitOne();
-        await Task.Delay(5000)
+        await Task.Delay(1500)
             .ConfigureAwait(false);
         await endpoint.Stop()
             .ConfigureAwait(false);

--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
@@ -69,7 +69,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.2.1\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.3.4\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>

--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/packages.config
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/packages.config
@@ -3,7 +3,7 @@
   <package id="ApprovalTests" version="3.0.13" targetFramework="net452" />
   <package id="ApprovalUtilities" version="3.0.13" targetFramework="net452" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net452" />
-  <package id="NServiceBus" version="6.2.1" targetFramework="net452" />
+  <package id="NServiceBus" version="6.3.4" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
   <package id="PublicApiGenerator" version="6.0.0" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
@@ -46,10 +46,10 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.2.1\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.3.4\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Metrics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.Metrics.1.0.0\lib\net452\NServiceBus.Metrics.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.Metrics.1.0.1\lib\net452\NServiceBus.Metrics.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/NServiceBus.Metrics.PerformanceCounters/packages.config
+++ b/src/NServiceBus.Metrics.PerformanceCounters/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="GitVersionTask" version="3.6.5" targetFramework="net452" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
-  <package id="NServiceBus" version="6.2.1" targetFramework="net452" />
-  <package id="NServiceBus.Metrics" version="1.0.0" targetFramework="net452" />
+  <package id="NServiceBus" version="6.3.4" targetFramework="net452" />
+  <package id="NServiceBus.Metrics" version="1.0.1" targetFramework="net452" />
   <package id="NuGetPackager" version="0.6.1" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/src/ScriptBuilderTask.Tests/CSharpCodeGenerationTests.Generates.approved.cs
+++ b/src/ScriptBuilderTask.Tests/CSharpCodeGenerationTests.Generates.approved.cs
@@ -32,7 +32,7 @@ public static class CounterCreator
     static CounterCreationData[] Counters = new CounterCreationData[]
     {
         new CounterCreationData("SLA violation countdown", "Seconds until the SLA for this endpoint is breached.", PerformanceCounterType.NumberOfItems32),
-        new CounterCreationData("Critical Time", "Age of the oldest message in the queue.", PerformanceCounterType.NumberOfItems32),
+        new CounterCreationData("Critical Time", "The time it took from sending to processing the message.", PerformanceCounterType.NumberOfItems32),
         new CounterCreationData("Processing Time", "The time it took to successfully process a message.", PerformanceCounterType.NumberOfItems32),
         new CounterCreationData("# of msgs pulled from the input queue /sec", "The current number of messages pulled from the input queue by the transport per second.", PerformanceCounterType.RateOfCountsPerSecond32),
         new CounterCreationData("# of msgs failures / sec", "The current number of failed processed messages by the transport per second.", PerformanceCounterType.RateOfCountsPerSecond32),

--- a/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
+++ b/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
@@ -6,7 +6,7 @@ Function InstallNSBPerfCounters {
     $counters = New-Object System.Diagnostics.CounterCreationDataCollection
     $counters.AddRange(@(
         New-Object System.Diagnostics.CounterCreationData "SLA violation countdown", "Seconds until the SLA for this endpoint is breached.",  NumberOfItems32
-        New-Object System.Diagnostics.CounterCreationData "Critical Time", "Age of the oldest message in the queue.",  NumberOfItems32
+        New-Object System.Diagnostics.CounterCreationData "Critical Time", "The time it took from sending to processing the message.",  NumberOfItems32
         New-Object System.Diagnostics.CounterCreationData "Processing Time", "The time it took to successfully process a message.",  NumberOfItems32
         New-Object System.Diagnostics.CounterCreationData "# of msgs pulled from the input queue /sec", "The current number of messages pulled from the input queue by the transport per second.",  RateOfCountsPerSecond32
         New-Object System.Diagnostics.CounterCreationData "# of msgs failures / sec", "The current number of failed processed messages by the transport per second.",  RateOfCountsPerSecond32

--- a/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
+++ b/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
@@ -40,10 +40,10 @@
       <HintPath>..\packages\ApprovalUtilities.3.0.13\lib\net45\ApprovalUtilities.Net45.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.2.1\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.3.4\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Metrics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.Metrics.1.0.0\lib\net452\NServiceBus.Metrics.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.Metrics.1.0.1\lib\net452\NServiceBus.Metrics.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>

--- a/src/ScriptBuilderTask.Tests/packages.config
+++ b/src/ScriptBuilderTask.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="ApprovalTests" version="3.0.13" targetFramework="net452" />
   <package id="ApprovalUtilities" version="3.0.13" targetFramework="net452" />
-  <package id="NServiceBus" version="6.2.1" targetFramework="net452" />
-  <package id="NServiceBus.Metrics" version="1.0.0" targetFramework="net452" />
+  <package id="NServiceBus" version="6.3.4" targetFramework="net452" />
+  <package id="NServiceBus.Metrics" version="1.0.1" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
@Particular/metrics-maintainers I updated to version NSB.Metrics 1.0.1 which is currently staged in MyGet. But `IntegrationTests.Ensure_counters_are_written` is failing because CriticalTime is zero. Is this test still valid?