### PR TITLE
New counters for critical and processing times

### DIFF
--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/MockIPerformanceCounter.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/MockIPerformanceCounter.cs
@@ -12,5 +12,10 @@
         RawValue++;
     }
 
+    public void IncrementBy(long value)
+    {
+        RawValue += value;
+    }
+
     public long RawValue { get; set; }
 }

--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/PerformanceCounterUpdaterTests.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/PerformanceCounterUpdaterTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using ApprovalUtilities.Utilities;
     using NServiceBus;
@@ -16,11 +17,11 @@
             var endpointName = "Sender@af016c07";
             var cache = new MockPerformanceCountersCache();
 
-            var signals = new []
+            var signals = new[]
             {
-                new MockSignalProbe("signal 1"), 
-                new MockSignalProbe("signal 2"), 
-                new MockSignalProbe("signal 3"), 
+                new MockSignalProbe("signal 1"),
+                new MockSignalProbe("signal 2"),
+                new MockSignalProbe("signal 3"),
             };
 
             var sut = new PerformanceCounterUpdater(cache, new Dictionary<string, CounterInstanceName?>(), endpointName);
@@ -54,7 +55,7 @@
 
             var sut = new PerformanceCounterUpdater(cache, legacyInstanceNameMap, "Sender@af016c07");
 
-            var signals = new []
+            var signals = new[]
             {
                 new MockSignalProbe("# of message failures / sec"),
                 new MockSignalProbe("# of messages pulled from the input queue / sec"),
@@ -76,7 +77,7 @@
             Assert.AreEqual(333, performanceCounterThree.RawValue);
         }
 
-        
+
         [Test]
         public void Duration_probes_within_payload_should_be_converted_into_performance_counters()
         {
@@ -91,23 +92,73 @@
 
             sut.Observe(new ProbeContext(durationProbes, new ISignalProbe[0]));
 
-            durationProbes[0].Observers(TimeSpan.FromSeconds(11));
-            durationProbes[1].Observers(TimeSpan.FromSeconds(22));
+            var timespan1 = TimeSpan.FromSeconds(11);
+            durationProbes[0].Observers(timespan1);
+            var timespan2 = TimeSpan.FromSeconds(22);
+            durationProbes[1].Observers(timespan2);
 
-            var performanceCounterOne = cache.Get(new CounterInstanceName("Critical Time", "Sender@af016c07"));
-            var performanceCounterTwo = cache.Get(new CounterInstanceName("Processing Time", "Sender@af016c07"));
+            // asserting the number of accessed counters
+            Assert.AreEqual(3 + 3, cache.Count);
+
+            var counter1 = cache.Get(new CounterInstanceName("Critical Time", "Sender@af016c07"));
+            var counter1average = cache.Get(new CounterInstanceName("Critical Time Average", "Sender@af016c07"));
+            var counter1averageBase = cache.Get(new CounterInstanceName("Critical Time AverageBase", "Sender@af016c07"));
+
+            var counter2 = cache.Get(new CounterInstanceName("Processing Time", "Sender@af016c07"));
+            var counter2average = cache.Get(new CounterInstanceName("Processing Time Average", "Sender@af016c07"));
+            var counter2averageBase = cache.Get(new CounterInstanceName("Processing Time AverageBase", "Sender@af016c07"));
+
+            Assert.AreEqual(11, counter1.RawValue);
+            Assert.AreEqual(CalculateAverageTimerCounterUpdate(timespan1), counter1average.RawValue);
+            Assert.AreEqual(1, counter1averageBase.RawValue);
+
+            Assert.AreEqual(22, counter2.RawValue);
+            Assert.AreEqual(CalculateAverageTimerCounterUpdate(timespan2), counter2average.RawValue);
+            Assert.AreEqual(1, counter2averageBase.RawValue);
+        }
+
+        [Test]
+        public void Duration_probes_within_payload_should_be_converted_into_performance_counters_with_no_raw_value_if_not_critical_or_processing_time()
+        {
+            var cache = new MockPerformanceCountersCache();
+            var sut = new PerformanceCounterUpdater(cache, new Dictionary<string, CounterInstanceName?>(), "Sender@af016c07");
+
+            var durationProbes = new[]
+            {
+                new MockDurationProbe("Any Other Timer"),
+            };
+
+            sut.Observe(new ProbeContext(durationProbes, new ISignalProbe[0]));
+
+            var timespan = TimeSpan.FromSeconds(11);
+            durationProbes[0].Observers(timespan);
+
+            // asserting the number of accessed counters
+            Assert.AreEqual(2, cache.Count);
             
-            Assert.AreEqual(11, performanceCounterOne.RawValue);
-            Assert.AreEqual(22, performanceCounterTwo.RawValue);
+            var counter1 = cache.Get(new CounterInstanceName("Any Other Timer", "Sender@af016c07"));
+            var counter1average = cache.Get(new CounterInstanceName("Any Other Timer Average", "Sender@af016c07"));
+            var counter1averageBase = cache.Get(new CounterInstanceName("Any Other Timer AverageBase", "Sender@af016c07"));
+
+            Assert.AreEqual(0, counter1.RawValue);
+            Assert.AreEqual(CalculateAverageTimerCounterUpdate(timespan), counter1average.RawValue);
+            Assert.AreEqual(1, counter1averageBase.RawValue);
+        }
+
+        static long CalculateAverageTimerCounterUpdate(TimeSpan d)
+        {
+            return d.Ticks * Stopwatch.Frequency / TimeSpan.TicksPerSecond;
         }
     }
-    
+
     class MockPerformanceCountersCache : PerformanceCountersCache
     {
         protected override IPerformanceCounterInstance CreateInstance(CounterInstanceName counterInstanceName)
         {
             return new MockIPerformanceCounter();
         }
+
+        public int Count => CountCounters();
     }
 
     class MockSignalProbe : ISignalProbe

--- a/src/NServiceBus.Metrics.PerformanceCounters/Counters/IPerformanceCounterInstance.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters/Counters/IPerformanceCounterInstance.cs
@@ -3,5 +3,6 @@ using System;
 interface IPerformanceCounterInstance : IDisposable
 {
     void Increment();
+    void IncrementBy(long value);
     long RawValue { get; set; }
 }

--- a/src/NServiceBus.Metrics.PerformanceCounters/Counters/PerformanceCounterInstance.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters/Counters/PerformanceCounterInstance.cs
@@ -12,6 +12,11 @@ class PerformanceCounterInstance : IPerformanceCounterInstance
         counter.Increment();
     }
 
+    public void IncrementBy(long value)
+    {
+        counter.IncrementBy(value);
+    }
+
     public void Dispose()
     {
         counter?.Dispose();

--- a/src/NServiceBus.Metrics.PerformanceCounters/Counters/PerformanceCountersCache.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters/Counters/PerformanceCountersCache.cs
@@ -42,5 +42,7 @@ class PerformanceCountersCache : IDisposable
         return new PerformanceCounterInstance(counter);
     }
 
+    protected int CountCounters() => counterCache.Count;
+
     ConcurrentDictionary<CounterInstanceName, IPerformanceCounterInstance> counterCache = new ConcurrentDictionary<CounterInstanceName, IPerformanceCounterInstance>();
 }

--- a/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
@@ -12,6 +12,9 @@
     <UpdateAssemblyInfo>true</UpdateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\ScriptBuilder\CounterNameConventions.cs" Link="CounterNameConventions.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NServiceBus" Version="6.3.4" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" />

--- a/src/ScriptBuilder/CSharpCounterWriter.cs
+++ b/src/ScriptBuilder/CSharpCounterWriter.cs
@@ -18,8 +18,17 @@
 
                 foreach (var duration in durations)
                 {
-                    var durationDefinition = $@"new CounterCreationData(""{duration.Name}"", ""{duration.Description}"", PerformanceCounterType.NumberOfItems32),";
-                    stringBuilder.AppendLine(durationDefinition.PadLeft(durationDefinition.Length + 8));
+                    var durationAverageDefinition = $@"new CounterCreationData(""{duration.Name} Average"", ""{duration.Description}"", PerformanceCounterType.AverageTimer32),";
+                    stringBuilder.AppendLine(durationAverageDefinition.PadLeft(durationAverageDefinition.Length + 8));
+
+                    var durationBaseDefinition = $@"new CounterCreationData(""{duration.Name} AverageBase"", ""{duration.Description}"", PerformanceCounterType.AverageBase),";
+                    stringBuilder.AppendLine(durationBaseDefinition.PadLeft(durationBaseDefinition.Length + 8));
+
+                    if (duration.Name == "Processing Time" || duration.Name == "Critical Time")
+                    {
+                        var legacyTimerDefinition = $@"new CounterCreationData(""{duration.Name}"", ""{duration.Description}"", PerformanceCounterType.NumberOfItems32),";
+                        stringBuilder.AppendLine(legacyTimerDefinition.PadLeft(legacyTimerDefinition.Length + 8));
+                    }
                 }
 
                 foreach (var signal in signals)

--- a/src/ScriptBuilder/CSharpCounterWriter.cs
+++ b/src/ScriptBuilder/CSharpCounterWriter.cs
@@ -18,13 +18,16 @@
 
                 foreach (var duration in durations)
                 {
-                    var durationAverageDefinition = $@"new CounterCreationData(""{duration.Name} Average"", ""{duration.Description}"", PerformanceCounterType.AverageTimer32),";
+                    var averageTimerName = duration.Name.GetAverageTimerCounterName();
+                    var averageTimerBase = duration.Name.GetAverageTimerBaseCounterName();
+
+                    var durationAverageDefinition = $@"new CounterCreationData(""{averageTimerName}"", ""{duration.Description}"", PerformanceCounterType.AverageTimer32),";
                     stringBuilder.AppendLine(durationAverageDefinition.PadLeft(durationAverageDefinition.Length + 8));
 
-                    var durationBaseDefinition = $@"new CounterCreationData(""{duration.Name} AverageBase"", ""{duration.Description}"", PerformanceCounterType.AverageBase),";
+                    var durationBaseDefinition = $@"new CounterCreationData(""{averageTimerBase}"", ""{duration.Description}"", PerformanceCounterType.AverageBase),";
                     stringBuilder.AppendLine(durationBaseDefinition.PadLeft(durationBaseDefinition.Length + 8));
 
-                    if (duration.Name == "Processing Time" || duration.Name == "Critical Time")
+                    if (duration.Name == CounterNameConventions.ProcessingTime || duration.Name == CounterNameConventions.CriticalTime)
                     {
                         var legacyTimerDefinition = $@"new CounterCreationData(""{duration.Name}"", ""{duration.Description}"", PerformanceCounterType.NumberOfItems32),";
                         stringBuilder.AppendLine(legacyTimerDefinition.PadLeft(legacyTimerDefinition.Length + 8));

--- a/src/ScriptBuilder/CounterNameConventions.cs
+++ b/src/ScriptBuilder/CounterNameConventions.cs
@@ -1,0 +1,18 @@
+﻿namespace NServiceBus.Metrics.PerformanceCounters
+{
+    static class CounterNameConventions
+    {
+        public static string GetAverageTimerCounterName(this string durationName)
+        {
+            return $"{durationName} Average";
+        }
+
+        public static string GetAverageTimerBaseCounterName(this string durationName)
+        {
+            return $"{durationName} AverageBase";
+        }
+
+        public const string ProcessingTime = "Processing Time";
+        public const string CriticalTime = "Critical Time";
+    }
+}

--- a/src/ScriptBuilder/PowerShellCounterWriter.cs
+++ b/src/ScriptBuilder/PowerShellCounterWriter.cs
@@ -18,19 +18,20 @@
 
                 foreach (var duration in durations)
                 {
-                    var durationAverageDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{duration.Name} Average"", ""{duration.Description}"",  AverageTimer32";
+                    var averageTimerName = duration.Name.GetAverageTimerCounterName();
+                    var averageTimerBase = duration.Name.GetAverageTimerBaseCounterName();
+
+                    var durationAverageDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{averageTimerName}"", ""{duration.Description}"",  AverageTimer32";
                     stringBuilder.AppendLine(durationAverageDefinition.PadLeft(durationAverageDefinition.Length + 8));
 
-                    var durationBaseDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{duration.Name} AverageBase"", ""{duration.Description}"",  AverageBase";
+                    var durationBaseDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{averageTimerBase}"", ""{duration.Description}"",  AverageBase";
                     stringBuilder.AppendLine(durationBaseDefinition.PadLeft(durationAverageDefinition.Length + 8));
                     
-                    if (duration.Name == "Processing Time" || duration.Name == "Critical Time")
+                    if (duration.Name == CounterNameConventions.ProcessingTime || duration.Name == CounterNameConventions.CriticalTime)
                     {
                         var legacyTimerDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{duration.Name}"", ""{duration.Description}"",  NumberOfItems32";
                         stringBuilder.AppendLine(legacyTimerDefinition.PadLeft(legacyTimerDefinition.Length + 8));
                     }
-
-                    
                 }
 
                 foreach (var signal in signals)

--- a/src/ScriptBuilder/PowerShellCounterWriter.cs
+++ b/src/ScriptBuilder/PowerShellCounterWriter.cs
@@ -18,8 +18,19 @@
 
                 foreach (var duration in durations)
                 {
-                    var durationDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{duration.Name}"", ""{duration.Description}"",  NumberOfItems32";
-                    stringBuilder.AppendLine(durationDefinition.PadLeft(durationDefinition.Length + 8));
+                    var durationAverageDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{duration.Name} Average"", ""{duration.Description}"",  AverageTimer32";
+                    stringBuilder.AppendLine(durationAverageDefinition.PadLeft(durationAverageDefinition.Length + 8));
+
+                    var durationBaseDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{duration.Name} AverageBase"", ""{duration.Description}"",  AverageBase";
+                    stringBuilder.AppendLine(durationBaseDefinition.PadLeft(durationAverageDefinition.Length + 8));
+                    
+                    if (duration.Name == "Processing Time" || duration.Name == "Critical Time")
+                    {
+                        var legacyTimerDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{duration.Name}"", ""{duration.Description}"",  NumberOfItems32";
+                        stringBuilder.AppendLine(legacyTimerDefinition.PadLeft(legacyTimerDefinition.Length + 8));
+                    }
+
+                    
                 }
 
                 foreach (var signal in signals)

--- a/src/ScriptBuilderTask.Tests/CSharpCodeGenerationTests.Generates.approved.cs
+++ b/src/ScriptBuilderTask.Tests/CSharpCodeGenerationTests.Generates.approved.cs
@@ -32,7 +32,11 @@ public static class CounterCreator
     static CounterCreationData[] Counters = new CounterCreationData[]
     {
         new CounterCreationData("SLA violation countdown", "Seconds until the SLA for this endpoint is breached.", PerformanceCounterType.NumberOfItems32),
+        new CounterCreationData("Critical Time Average", "The time it took from sending to processing the message.", PerformanceCounterType.AverageTimer32),
+        new CounterCreationData("Critical Time AverageBase", "The time it took from sending to processing the message.", PerformanceCounterType.AverageBase),
         new CounterCreationData("Critical Time", "The time it took from sending to processing the message.", PerformanceCounterType.NumberOfItems32),
+        new CounterCreationData("Processing Time Average", "The time it took to successfully process a message.", PerformanceCounterType.AverageTimer32),
+        new CounterCreationData("Processing Time AverageBase", "The time it took to successfully process a message.", PerformanceCounterType.AverageBase),
         new CounterCreationData("Processing Time", "The time it took to successfully process a message.", PerformanceCounterType.NumberOfItems32),
         new CounterCreationData("# of msgs failures / sec", "The current number of failed processed messages by the transport per second.", PerformanceCounterType.RateOfCountsPerSecond32),
         new CounterCreationData("# of msgs successfully processed / sec", "The current number of messages processed successfully by the transport per second.", PerformanceCounterType.RateOfCountsPerSecond32),

--- a/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
+++ b/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
@@ -6,7 +6,11 @@ Function InstallNSBPerfCounters {
     $counters = New-Object System.Diagnostics.CounterCreationDataCollection
     $counters.AddRange(@(
         New-Object System.Diagnostics.CounterCreationData "SLA violation countdown", "Seconds until the SLA for this endpoint is breached.",  NumberOfItems32
+        New-Object System.Diagnostics.CounterCreationData "Critical Time Average", "The time it took from sending to processing the message.",  AverageTimer32
+       New-Object System.Diagnostics.CounterCreationData "Critical Time AverageBase", "The time it took from sending to processing the message.",  AverageBase
         New-Object System.Diagnostics.CounterCreationData "Critical Time", "The time it took from sending to processing the message.",  NumberOfItems32
+        New-Object System.Diagnostics.CounterCreationData "Processing Time Average", "The time it took to successfully process a message.",  AverageTimer32
+       New-Object System.Diagnostics.CounterCreationData "Processing Time AverageBase", "The time it took to successfully process a message.",  AverageBase
         New-Object System.Diagnostics.CounterCreationData "Processing Time", "The time it took to successfully process a message.",  NumberOfItems32
         New-Object System.Diagnostics.CounterCreationData "# of msgs failures / sec", "The current number of failed processed messages by the transport per second.",  RateOfCountsPerSecond32
         New-Object System.Diagnostics.CounterCreationData "# of msgs successfully processed / sec", "The current number of messages processed successfully by the transport per second.",  RateOfCountsPerSecond32


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/1332

## Description
This PR changes the type of performance counters that are generated for duration probes to composite counter made of `AverageTimer32` and `AverageBase`.

For backwards compatibility reasons deployment scripts treat `Critial Time` and `Processing Time` specially and generate `NumberOfItems32` counter as well.

## PoA

- [x] Update deployment scripts
- [x] Attach to duration probes and update performance counters

## This is how counters are presented after this PR

<img width="646" alt="perf-counters" src="https://user-images.githubusercontent.com/519707/28566267-e9eea198-712e-11e7-87da-667bb771ae6d.png">