### PR TITLE
Performance counter creation script always deletes `nservicebus` category

### DIFF
--- a/src/ScriptBuilderTask.Tests/CSharpCodeGenerationTests.Generates.approved.cs
+++ b/src/ScriptBuilderTask.Tests/CSharpCodeGenerationTests.Generates.approved.cs
@@ -4,27 +4,39 @@ using System.Security;
 using System.Runtime.CompilerServices;
 
 [CompilerGenerated]
-public static class CounterCreator
+public static class CounterCreator 
 {
-    public static void Create()
+    public static void Create() 
     {
         var counterCreationCollection = new CounterCreationDataCollection(Counters);
         try
         {
             var categoryName = "NServiceBus";
+
             if (PerformanceCounterCategory.Exists(categoryName))
             {
-                PerformanceCounterCategory.Delete(categoryName);
+                foreach (CounterCreationData counter in counterCreationCollection)
+                {
+                    if (!PerformanceCounterCategory.CounterExists(counter.CounterName, categoryName))
+                    {
+                        PerformanceCounterCategory.Delete(categoryName);
+                        break;
+                    }
+                }
             }
 
-            PerformanceCounterCategory.Create(
-                categoryName: categoryName,
-                categoryHelp: "NServiceBus statistics",
-                categoryType: PerformanceCounterCategoryType.MultiInstance,
-                counterData: counterCreationCollection);
+            if (PerformanceCounterCategory.Exists(categoryName) == false)
+            {
+                PerformanceCounterCategory.Create(
+                    categoryName: categoryName,
+                    categoryHelp: "NServiceBus statistics",
+                    categoryType: PerformanceCounterCategoryType.MultiInstance,
+                    counterData: counterCreationCollection);
+            }
+
             PerformanceCounter.CloseSharedResources();
         }
-        catch (Exception ex) when (ex is SecurityException || ex is UnauthorizedAccessException)
+        catch (Exception ex) when(ex is SecurityException || ex is UnauthorizedAccessException)
         {
             throw new Exception("Execution requires elevated permissions", ex);
         }

--- a/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
+++ b/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
@@ -16,7 +16,6 @@ Function InstallNSBPerfCounters {
 		New-Object System.Diagnostics.CounterCreationData "# of msgs successfully processed / sec", "The current number of messages processed successfully by the transport per second.",  RateOfCountsPerSecond32
 		New-Object System.Diagnostics.CounterCreationData "# of msgs pulled from the input queue /sec", "The current number of messages pulled from the input queue by the transport per second.",  RateOfCountsPerSecond32
 		New-Object System.Diagnostics.CounterCreationData "Retries", "A message has been scheduled for retry (FLR or SLR)",  RateOfCountsPerSecond32
-
     ))
 
 	$shouldCreate = $true
@@ -27,15 +26,16 @@ Function InstallNSBPerfCounters {
 		foreach($counter in $counters){
 			$exists = [System.Diagnostics.PerformanceCounterCategory]::CounterExists($counter.CounterName, $category.Name)
 			if (!$exists){
-                Write-Host "One or more counters are missing. The performance counter category will be recreated"
 				$shouldCreate = $true
-			    [System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
 				break
 			}
 		}
     }
 
 	if ($shouldCreate){
+		Write-Host "One or more counters are missing. The performance counter category will be recreated"
+		[System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
+
         Write-Host "Creating the performance counter category"
 		[void] [System.Diagnostics.PerformanceCounterCategory]::Create($category.Name, $category.Description, [System.Diagnostics.PerformanceCounterCategoryType]::MultiInstance, $counters)
 	}

--- a/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
+++ b/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
@@ -18,24 +18,20 @@ Function InstallNSBPerfCounters {
 		New-Object System.Diagnostics.CounterCreationData "Retries", "A message has been scheduled for retry (FLR or SLR)",  RateOfCountsPerSecond32
     ))
 
-	$shouldCreate = $true
 	if ([System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {
 		
-		$shouldCreate = $false
-
 		foreach($counter in $counters){
 			$exists = [System.Diagnostics.PerformanceCounterCategory]::CounterExists($counter.CounterName, $category.Name)
 			if (!$exists){
-				$shouldCreate = $true
+				Write-Host "One or more counters are missing. The performance counter category will be recreated"
+				[System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
+
 				break
 			}
 		}
     }
 
-	if ($shouldCreate){
-		Write-Host "One or more counters are missing. The performance counter category will be recreated"
-		[System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
-
+	if (![System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {
         Write-Host "Creating the performance counter category"
 		[void] [System.Diagnostics.PerformanceCounterCategory]::Create($category.Name, $category.Description, [System.Diagnostics.PerformanceCounterCategoryType]::MultiInstance, $counters)
 	}

--- a/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
+++ b/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
@@ -1,44 +1,45 @@
 
 #requires -RunAsAdministrator
 Function InstallNSBPerfCounters {
-
+    
     $category = @{Name="NServiceBus"; Description="NServiceBus statistics"}
     $counters = New-Object System.Diagnostics.CounterCreationDataCollection
     $counters.AddRange(@(
-		New-Object System.Diagnostics.CounterCreationData "SLA violation countdown", "Seconds until the SLA for this endpoint is breached.",  NumberOfItems32
-		New-Object System.Diagnostics.CounterCreationData "Critical Time Average", "The time it took from sending to processing the message.",  AverageTimer32
-		New-Object System.Diagnostics.CounterCreationData "Critical Time AverageBase", "The time it took from sending to processing the message.",  AverageBase
-		New-Object System.Diagnostics.CounterCreationData "Critical Time", "The time it took from sending to processing the message.",  NumberOfItems32
-		New-Object System.Diagnostics.CounterCreationData "Processing Time Average", "The time it took to successfully process a message.",  AverageTimer32
-		New-Object System.Diagnostics.CounterCreationData "Processing Time AverageBase", "The time it took to successfully process a message.",  AverageBase
-		New-Object System.Diagnostics.CounterCreationData "Processing Time", "The time it took to successfully process a message.",  NumberOfItems32
-		New-Object System.Diagnostics.CounterCreationData "# of msgs failures / sec", "The current number of failed processed messages by the transport per second.",  RateOfCountsPerSecond32
-		New-Object System.Diagnostics.CounterCreationData "# of msgs successfully processed / sec", "The current number of messages processed successfully by the transport per second.",  RateOfCountsPerSecond32
-		New-Object System.Diagnostics.CounterCreationData "# of msgs pulled from the input queue /sec", "The current number of messages pulled from the input queue by the transport per second.",  RateOfCountsPerSecond32
-		New-Object System.Diagnostics.CounterCreationData "Retries", "A message has been scheduled for retry (FLR or SLR)",  RateOfCountsPerSecond32
+        New-Object System.Diagnostics.CounterCreationData "SLA violation countdown", "Seconds until the SLA for this endpoint is breached.",  NumberOfItems32
+        New-Object System.Diagnostics.CounterCreationData "Critical Time Average", "The time it took from sending to processing the message.",  AverageTimer32
+        New-Object System.Diagnostics.CounterCreationData "Critical Time AverageBase", "The time it took from sending to processing the message.",  AverageBase
+        New-Object System.Diagnostics.CounterCreationData "Critical Time", "The time it took from sending to processing the message.",  NumberOfItems32
+        New-Object System.Diagnostics.CounterCreationData "Processing Time Average", "The time it took to successfully process a message.",  AverageTimer32
+        New-Object System.Diagnostics.CounterCreationData "Processing Time AverageBase", "The time it took to successfully process a message.",  AverageBase
+        New-Object System.Diagnostics.CounterCreationData "Processing Time", "The time it took to successfully process a message.",  NumberOfItems32
+        New-Object System.Diagnostics.CounterCreationData "# of msgs failures / sec", "The current number of failed processed messages by the transport per second.",  RateOfCountsPerSecond32
+        New-Object System.Diagnostics.CounterCreationData "# of msgs successfully processed / sec", "The current number of messages processed successfully by the transport per second.",  RateOfCountsPerSecond32
+        New-Object System.Diagnostics.CounterCreationData "# of msgs pulled from the input queue /sec", "The current number of messages pulled from the input queue by the transport per second.",  RateOfCountsPerSecond32
+        New-Object System.Diagnostics.CounterCreationData "Retries", "A message has been scheduled for retry (FLR or SLR)",  RateOfCountsPerSecond32
+
     ))
 
-	if ([System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {
-		
-		foreach($counter in $counters){
-			$exists = [System.Diagnostics.PerformanceCounterCategory]::CounterExists($counter.CounterName, $category.Name)
-			if (!$exists){
-				Write-Host "One or more counters are missing. The performance counter category will be recreated"
-				[System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
+    if ([System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {
 
-				break
-			}
-		}
+       foreach($counter in $counters){
+            $exists = [System.Diagnostics.PerformanceCounterCategory]::CounterExists($counter.CounterName, $category.Name)
+            if (!$exists){
+                Write-Host "One or more counters are missing.The performance counter category will be recreated"
+                [System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
+
+                break
+            }
+        }
     }
 
-	if (![System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {
+    if (![System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {
         Write-Host "Creating the performance counter category"
-		[void] [System.Diagnostics.PerformanceCounterCategory]::Create($category.Name, $category.Description, [System.Diagnostics.PerformanceCounterCategoryType]::MultiInstance, $counters)
-	}
-	else {
-		Write-Host "No performance counters have to be created"
-	}
-    
+        [void] [System.Diagnostics.PerformanceCounterCategory]::Create($category.Name, $category.Description, [System.Diagnostics.PerformanceCounterCategoryType]::MultiInstance, $counters)
+        }
+    else {
+        Write-Host "No performance counters have to be created"
+    }
+
     [System.Diagnostics.PerformanceCounter]::CloseSharedResources()
 }
 InstallNSBPerfCounters

--- a/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
+++ b/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
@@ -5,23 +5,44 @@ Function InstallNSBPerfCounters {
     $category = @{Name="NServiceBus"; Description="NServiceBus statistics"}
     $counters = New-Object System.Diagnostics.CounterCreationDataCollection
     $counters.AddRange(@(
-        New-Object System.Diagnostics.CounterCreationData "SLA violation countdown", "Seconds until the SLA for this endpoint is breached.",  NumberOfItems32
-        New-Object System.Diagnostics.CounterCreationData "Critical Time Average", "The time it took from sending to processing the message.",  AverageTimer32
-       New-Object System.Diagnostics.CounterCreationData "Critical Time AverageBase", "The time it took from sending to processing the message.",  AverageBase
-        New-Object System.Diagnostics.CounterCreationData "Critical Time", "The time it took from sending to processing the message.",  NumberOfItems32
-        New-Object System.Diagnostics.CounterCreationData "Processing Time Average", "The time it took to successfully process a message.",  AverageTimer32
-       New-Object System.Diagnostics.CounterCreationData "Processing Time AverageBase", "The time it took to successfully process a message.",  AverageBase
-        New-Object System.Diagnostics.CounterCreationData "Processing Time", "The time it took to successfully process a message.",  NumberOfItems32
-        New-Object System.Diagnostics.CounterCreationData "# of msgs failures / sec", "The current number of failed processed messages by the transport per second.",  RateOfCountsPerSecond32
-        New-Object System.Diagnostics.CounterCreationData "# of msgs successfully processed / sec", "The current number of messages processed successfully by the transport per second.",  RateOfCountsPerSecond32
-        New-Object System.Diagnostics.CounterCreationData "# of msgs pulled from the input queue /sec", "The current number of messages pulled from the input queue by the transport per second.",  RateOfCountsPerSecond32
-        New-Object System.Diagnostics.CounterCreationData "Retries", "A message has been scheduled for retry (FLR or SLR)",  RateOfCountsPerSecond32
+		New-Object System.Diagnostics.CounterCreationData "SLA violation countdown", "Seconds until the SLA for this endpoint is breached.",  NumberOfItems32
+		New-Object System.Diagnostics.CounterCreationData "Critical Time Average", "The time it took from sending to processing the message.",  AverageTimer32
+		New-Object System.Diagnostics.CounterCreationData "Critical Time AverageBase", "The time it took from sending to processing the message.",  AverageBase
+		New-Object System.Diagnostics.CounterCreationData "Critical Time", "The time it took from sending to processing the message.",  NumberOfItems32
+		New-Object System.Diagnostics.CounterCreationData "Processing Time Average", "The time it took to successfully process a message.",  AverageTimer32
+		New-Object System.Diagnostics.CounterCreationData "Processing Time AverageBase", "The time it took to successfully process a message.",  AverageBase
+		New-Object System.Diagnostics.CounterCreationData "Processing Time", "The time it took to successfully process a message.",  NumberOfItems32
+		New-Object System.Diagnostics.CounterCreationData "# of msgs failures / sec", "The current number of failed processed messages by the transport per second.",  RateOfCountsPerSecond32
+		New-Object System.Diagnostics.CounterCreationData "# of msgs successfully processed / sec", "The current number of messages processed successfully by the transport per second.",  RateOfCountsPerSecond32
+		New-Object System.Diagnostics.CounterCreationData "# of msgs pulled from the input queue /sec", "The current number of messages pulled from the input queue by the transport per second.",  RateOfCountsPerSecond32
+		New-Object System.Diagnostics.CounterCreationData "Retries", "A message has been scheduled for retry (FLR or SLR)",  RateOfCountsPerSecond32
 
     ))
-    if ([System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {
-        [System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
+
+	$shouldCreate = $true
+	if ([System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {
+		
+		$shouldCreate = $false
+
+		foreach($counter in $counters){
+			$exists = [System.Diagnostics.PerformanceCounterCategory]::CounterExists($counter.CounterName, $category.Name)
+			if (!$exists){
+                Write-Host "One or more counters are missing. The performance counter category will be recreated"
+				$shouldCreate = $true
+			    [System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
+				break
+			}
+		}
     }
-    [void] [System.Diagnostics.PerformanceCounterCategory]::Create($category.Name, $category.Description, [System.Diagnostics.PerformanceCounterCategoryType]::MultiInstance, $counters)
+
+	if ($shouldCreate){
+        Write-Host "Creating the performance counter category"
+		[void] [System.Diagnostics.PerformanceCounterCategory]::Create($category.Name, $category.Description, [System.Diagnostics.PerformanceCounterCategoryType]::MultiInstance, $counters)
+	}
+	else {
+		Write-Host "No performance counters have to be created"
+	}
+    
     [System.Diagnostics.PerformanceCounter]::CloseSharedResources()
 }
 InstallNSBPerfCounters

--- a/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.cs
+++ b/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Runtime.CompilerServices;
     using ApprovalTests;
+    using ApprovalTests.Reporters;
     using NServiceBus.Metrics.PerformanceCounters;
     using NUnit.Framework;
 
@@ -34,6 +35,8 @@
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Generates()
         {
+            GenericDiffReporter.RegisterTextFileTypes(".ps1");
+
             task.Execute();
 
             var powershell = Directory.EnumerateFiles(tempPath, "*.ps1", SearchOption.AllDirectories).Single();

--- a/src/ScriptBuilderTask/CSharpCounterWriter.cs
+++ b/src/ScriptBuilderTask/CSharpCounterWriter.cs
@@ -36,7 +36,7 @@
 
                 foreach (var signal in signals)
                 {
-                    legacyInstanceNameMap.TryGetValue(signal.Name, out string instanceName);
+                    legacyInstanceNameMap.TryGetValue(signal.Name, out var instanceName);
 
                     var signalDefinition = $@"new CounterCreationData(""{instanceName ?? signal.Name}"", ""{signal.Description}"", PerformanceCounterType.RateOfCountsPerSecond32),";
                     stringBuilder.AppendLine(signalDefinition.PadLeft(signalDefinition.Length + 8));

--- a/src/ScriptBuilderTask/CSharpCounterWriter.cs
+++ b/src/ScriptBuilderTask/CSharpCounterWriter.cs
@@ -36,8 +36,7 @@
 
                 foreach (var signal in signals)
                 {
-                    string instanceName;
-                    legacyInstanceNameMap.TryGetValue(signal.Name, out instanceName);
+                    legacyInstanceNameMap.TryGetValue(signal.Name, out string instanceName);
 
                     var signalDefinition = $@"new CounterCreationData(""{instanceName ?? signal.Name}"", ""{signal.Description}"", PerformanceCounterType.RateOfCountsPerSecond32),";
                     stringBuilder.AppendLine(signalDefinition.PadLeft(signalDefinition.Length + 8));

--- a/src/ScriptBuilderTask/CSharpCounterWriter.cs
+++ b/src/ScriptBuilderTask/CSharpCounterWriter.cs
@@ -36,7 +36,8 @@
 
                 foreach (var signal in signals)
                 {
-                    legacyInstanceNameMap.TryGetValue(signal.Name, out var instanceName);
+                    string instanceName;
+                    legacyInstanceNameMap.TryGetValue(signal.Name, out instanceName);
 
                     var signalDefinition = $@"new CounterCreationData(""{instanceName ?? signal.Name}"", ""{signal.Description}"", PerformanceCounterType.RateOfCountsPerSecond32),";
                     stringBuilder.AppendLine(signalDefinition.PadLeft(signalDefinition.Length + 8));
@@ -52,27 +53,39 @@ using System.Security;
 using System.Runtime.CompilerServices;
 
 [CompilerGenerated]
-public static class CounterCreator
+public static class CounterCreator 
 {{
-    public static void Create()
+    public static void Create() 
     {{
         var counterCreationCollection = new CounterCreationDataCollection(Counters);
         try
         {{
             var categoryName = ""NServiceBus"";
+
             if (PerformanceCounterCategory.Exists(categoryName))
             {{
-                PerformanceCounterCategory.Delete(categoryName);
+                foreach (CounterCreationData counter in counterCreationCollection)
+                {{
+                    if (!PerformanceCounterCategory.CounterExists(counter.CounterName, categoryName))
+                    {{
+                        PerformanceCounterCategory.Delete(categoryName);
+                        break;
+                    }}
+                }}
             }}
 
-            PerformanceCounterCategory.Create(
-                categoryName: categoryName,
-                categoryHelp: ""NServiceBus statistics"",
-                categoryType: PerformanceCounterCategoryType.MultiInstance,
-                counterData: counterCreationCollection);
+            if (PerformanceCounterCategory.Exists(categoryName) == false)
+            {{
+                PerformanceCounterCategory.Create(
+                    categoryName: categoryName,
+                    categoryHelp: ""NServiceBus statistics"",
+                    categoryType: PerformanceCounterCategoryType.MultiInstance,
+                    counterData: counterCreationCollection);
+            }}
+
             PerformanceCounter.CloseSharedResources();
         }}
-        catch (Exception ex) when (ex is SecurityException || ex is UnauthorizedAccessException)
+        catch (Exception ex) when(ex is SecurityException || ex is UnauthorizedAccessException)
         {{
             throw new Exception(""Execution requires elevated permissions"", ex);
         }}

--- a/src/ScriptBuilderTask/PowerShellCounterWriter.cs
+++ b/src/ScriptBuilderTask/PowerShellCounterWriter.cs
@@ -36,8 +36,7 @@
 
                 foreach (var signal in signals)
                 {
-                    string instanceName;
-                    legacyInstanceNameMap.TryGetValue(signal.Name, out instanceName);
+                    legacyInstanceNameMap.TryGetValue(signal.Name, out string instanceName);
 
                     var signalDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{instanceName ?? signal.Name}"", ""{signal.Description}"",  RateOfCountsPerSecond32";
                     stringBuilder.AppendLine(signalDefinition.PadLeft(signalDefinition.Length + 8));

--- a/src/ScriptBuilderTask/PowerShellCounterWriter.cs
+++ b/src/ScriptBuilderTask/PowerShellCounterWriter.cs
@@ -36,7 +36,7 @@
 
                 foreach (var signal in signals)
                 {
-                    legacyInstanceNameMap.TryGetValue(signal.Name, out string instanceName);
+                    legacyInstanceNameMap.TryGetValue(signal.Name, out var instanceName);
 
                     var signalDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{instanceName ?? signal.Name}"", ""{signal.Description}"",  RateOfCountsPerSecond32";
                     stringBuilder.AppendLine(signalDefinition.PadLeft(signalDefinition.Length + 8));

--- a/src/ScriptBuilderTask/PowerShellCounterWriter.cs
+++ b/src/ScriptBuilderTask/PowerShellCounterWriter.cs
@@ -50,7 +50,7 @@
         const string Template = @"
 #requires -RunAsAdministrator
 Function InstallNSBPerfCounters {{
-
+    
     $category = @{{Name=""NServiceBus""; Description=""NServiceBus statistics""}}
     $counters = New-Object System.Diagnostics.CounterCreationDataCollection
     $counters.AddRange(@(
@@ -58,12 +58,11 @@ Function InstallNSBPerfCounters {{
     ))
 
     if ([System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {{
-		
-	    foreach($counter in $counters){{
-		    $exists = [System.Diagnostics.PerformanceCounterCategory]::CounterExists($counter.CounterName, $category.Name)
-			if (!$exists){{
-				Write-Host ""One or more counters are missing.The performance counter category will be recreated""
 
+       foreach($counter in $counters){{
+            $exists = [System.Diagnostics.PerformanceCounterCategory]::CounterExists($counter.CounterName, $category.Name)
+            if (!$exists){{
+                Write-Host ""One or more counters are missing.The performance counter category will be recreated""
                 [System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
 
                 break

--- a/src/ScriptBuilderTask/PowerShellCounterWriter.cs
+++ b/src/ScriptBuilderTask/PowerShellCounterWriter.cs
@@ -25,8 +25,8 @@
                     stringBuilder.AppendLine(durationAverageDefinition.PadLeft(durationAverageDefinition.Length + 8));
 
                     var durationBaseDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{averageTimerBase}"", ""{duration.Description}"",  AverageBase";
-                    stringBuilder.AppendLine(durationBaseDefinition.PadLeft(durationAverageDefinition.Length + 8));
-
+                    stringBuilder.AppendLine(durationBaseDefinition.PadLeft(durationBaseDefinition.Length + 8));
+                    
                     if (duration.Name == CounterNameConventions.ProcessingTime || duration.Name == CounterNameConventions.CriticalTime)
                     {
                         var legacyTimerDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{duration.Name}"", ""{duration.Description}"",  NumberOfItems32";
@@ -36,7 +36,8 @@
 
                 foreach (var signal in signals)
                 {
-                    legacyInstanceNameMap.TryGetValue(signal.Name, out var instanceName);
+                    string instanceName;
+                    legacyInstanceNameMap.TryGetValue(signal.Name, out instanceName);
 
                     var signalDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{instanceName ?? signal.Name}"", ""{signal.Description}"",  RateOfCountsPerSecond32";
                     stringBuilder.AppendLine(signalDefinition.PadLeft(signalDefinition.Length + 8));
@@ -55,10 +56,29 @@ Function InstallNSBPerfCounters {{
     $counters.AddRange(@(
 {0}
     ))
+
     if ([System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {{
-        [System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
+		
+	    foreach($counter in $counters){{
+		    $exists = [System.Diagnostics.PerformanceCounterCategory]::CounterExists($counter.CounterName, $category.Name)
+			if (!$exists){{
+				Write-Host ""One or more counters are missing.The performance counter category will be recreated""
+
+                [System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
+
+                break
+            }}
+        }}
     }}
-    [void] [System.Diagnostics.PerformanceCounterCategory]::Create($category.Name, $category.Description, [System.Diagnostics.PerformanceCounterCategoryType]::MultiInstance, $counters)
+
+    if (![System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {{
+        Write-Host ""Creating the performance counter category""
+        [void] [System.Diagnostics.PerformanceCounterCategory]::Create($category.Name, $category.Description, [System.Diagnostics.PerformanceCounterCategoryType]::MultiInstance, $counters)
+        }}
+    else {{
+        Write-Host ""No performance counters have to be created""
+    }}
+
     [System.Diagnostics.PerformanceCounter]::CloseSharedResources()
 }}
 InstallNSBPerfCounters


### PR DESCRIPTION
Connects to #25 

This PR changes the way, in which performance counters are created. It introduces changes that, before aggressive category recreation, check whether all the required counters are created. If yes, the recreation is postponed. This approach has been inspired by [NServiceBus.PowerShell](https://github.com/Particular/NServiceBus.PowerShell/blob/develop/src/NServiceBus.PowerShell/PerformanceCounters/PerformanceCounterSetup.cs).

See #25 for more details.