### PR TITLE
JSON.NET and unneeded ILMerge removed

### DIFF
--- a/packaging/nuget/NServiceBus.Metrics.PerformanceCounters.nuspec
+++ b/packaging/nuget/NServiceBus.Metrics.PerformanceCounters.nuspec
@@ -19,6 +19,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\..\binaries\NServiceBus.Metrics.PerformanceCounters.???" target="lib\net452" />
+    <file src="..\..\binaries\net452\NServiceBus.Metrics.PerformanceCounters.???" target="lib\net452" />
   </files>
 </package>

--- a/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
@@ -18,24 +18,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Metrics" Version="2.0.0-*" />
+    <PackageReference Include="NServiceBus" Version="6.3.4" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" />
     <PackageReference Include="NuGetPackager" Version="0.6.3" />
   </ItemGroup>
-  <Target Name="BeforeBuildPackages" BeforeTargets="BuildPackages">
-    <MakeDir Directories="$(TargetDir)temp\" />
-    <Exec Command="&quot;$(SolutionDir)..\tools\ilmerge.exe&quot; /log:$(TargetDir)ilmerge.log /keyfile:&quot;$(SolutionDir)NServiceBus.snk&quot; /internalize /out:&quot;$(TargetDir)temp\$(TargetFileName)&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)Newtonsoft.Json.dll&quot; /target:library /targetplatform:&quot;v4,$(FrameworkPathOverride)&quot;" />
-    <ItemGroup>
-      <TempFiles Include="$(TargetDir)temp\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(TempFiles)" DestinationFolder="$(TargetDir)" OverwriteReadOnlyFiles="true" />
-    <Delete Files="@(TempFiles)" />
-    <RemoveDir Directories="$(TargetDir)temp\" />
-    <MakeDir Directories="$(SolutionDir)..\binaries" />
-    <ItemGroup>
-      <Files Include="$(TargetDir)$(TargetName).*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Files)" DestinationFolder="$(SolutionDir)..\binaries" />
-    <MakeDir Directories="$(SolutionDir)ForIntegration" />
-    <Copy SourceFiles="@(Files)" DestinationFolder="$(SolutionDir)ForIntegration" />
-  </Target>
 </Project>

--- a/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
@@ -11,6 +11,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <UpdateAssemblyInfo>true</UpdateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>..\..\binaries\</OutputPath>
+    <DocumentationFile>..\..\binaries\NServiceBus.Metrics.PerformanceCounters.xml</DocumentationFile>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\ScriptBuilder\CounterNameConventions.cs" Link="CounterNameConventions.cs" />
   </ItemGroup>


### PR DESCRIPTION
Connects to #30 

This PR removes unneeded `JSON.NET` package and simplifies the build process of `NServiceBus.Metrics.PerformanceCounters` as ILMerge is no longer required.