### PR TITLE
Timers are reset after not receiving pipeline completion for 2 seconds

### DIFF
--- a/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersFeature.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersFeature.cs
@@ -31,6 +31,12 @@ class PerformanceCountersFeature : Feature
 
         context.RegisterStartupTask(new Cleanup(this));
 
+        context.Pipeline.OnReceivePipelineCompleted(_=>
+        {
+            updater.OnReceivePipelineCompleted();
+            return TaskExtensions.CompletedTask;
+        });
+
         options.EnableCustomReport(payload =>
         {
             updater?.Update(payload);


### PR DESCRIPTION
This PR addresses #38, clearing performance counters of `Critical Time` and `Processing Time` after 2s of inactivity.
Once it's released, #25 could be closed