### PR TITLE
Proper Metrics 2.0

### DIFF
--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/EndpointConfigBuilder.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/EndpointConfigBuilder.cs
@@ -5,7 +5,7 @@ static class EndpointConfigBuilder
     public static EndpointConfiguration BuildEndpoint(string s)
     {
         var endpointConfiguration = new EndpointConfiguration(s);
-        endpointConfiguration.UseTransport<LearningTransport>();
+        endpointConfiguration.UseTransport<MsmqTransport>();
         endpointConfiguration.SendFailedMessagesTo("error");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseSerialization<NewtonsoftSerializer>();

--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/EndpointConfigBuilder.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/EndpointConfigBuilder.cs
@@ -5,7 +5,7 @@ static class EndpointConfigBuilder
     public static EndpointConfiguration BuildEndpoint(string s)
     {
         var endpointConfiguration = new EndpointConfiguration(s);
-        endpointConfiguration.UseTransport<MsmqTransport>();
+        endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.SendFailedMessagesTo("error");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseSerialization<NewtonsoftSerializer>();

--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
@@ -16,9 +16,8 @@
     <PackageReference Include="ApprovalTests" Version="3.*" />
     <PackageReference Include="ApprovalUtilities" Version="3.*" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-*" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Metrics" Version="2.0.0-*" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
+    <PackageReference Include="NServiceBus.Metrics" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="1.1.0" />
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="ApiApprover" Version="6.1.0-*" />
     <PackageReference Include="PublicApiGenerator" Version="6.1.0-*" />

--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="ApprovalTests" Version="3.*" />
     <PackageReference Include="ApprovalUtilities" Version="3.*" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-*" />
+    <PackageReference Include="NServiceBus" Version="6.4.2" />
     <PackageReference Include="NServiceBus.Metrics" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="1.1.0" />
     <PackageReference Include="NUnit" Version="3.*" />

--- a/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
@@ -13,8 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="4.0.0-*" PrivateAssets="All" />
-    <PackageReference Include="NServiceBus" Version="[7.0.0-*, 8.0.0)" />
-    <PackageReference Include="NServiceBus.Metrics" Version="[2.0.0-*, 3.0.0)" />
+    <PackageReference Include="NServiceBus.Metrics" Version="[2.0.0, 3.0.0)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersSettings.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersSettings.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
-    using Configuration.AdvancedExtensibility;
+    using Configuration.AdvanceExtensibility;
 
     /// <summary>
     /// Windows performance counter configuration instance.

--- a/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
+++ b/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
@@ -10,8 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="ApprovalUtilities" Version="3.0.13" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Metrics" Version="2.0.0-*" />
+    <PackageReference Include="NServiceBus.Metrics" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <ProjectReference Include="..\ScriptBuilderTask\ScriptBuilderTask.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This PR aligns `develop` to the version of Metrics 2.0 that has been released. In other words, it moves this package's version 2.0 back to NSB core v6, leaving migration to 7.0 for the 3.0 of this package.

This PR will be shortly followed by a release.