### PR TITLE
UpdateInterval proper obsoletion

### DIFF
--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.approved.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.approved.cs
@@ -23,5 +23,9 @@ namespace NServiceBus
     public class PerformanceCountersSettings
     {
         public void EnableSLAPerformanceCounters(System.TimeSpan sla) { }
+        [System.ObsoleteAttribute("This interval is no longer used for reporting. Counters values are updated as soo" +
+            "n as they are reported. Will be treated as an error from version 2.0.0. Will be " +
+            "removed in version 3.0.0.", false)]
+        public void UpdateCounterEvery(System.TimeSpan updateInterval) { }
     }
 }

--- a/src/NServiceBus.Metrics.PerformanceCounters/FodyWeavers.xml
+++ b/src/NServiceBus.Metrics.PerformanceCounters/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers>
+  <Obsolete />
+</Weavers>

--- a/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="4.0.0-*" PrivateAssets="All" />
     <PackageReference Include="NServiceBus.Metrics" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Obsolete.Fody" Version="4.3.2" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersSettings.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersSettings.cs
@@ -26,5 +26,14 @@
             endpointConfiguration.GetSettings().Set(SLAMonitoringFeature.EndpointSLAKey, sla);
             endpointConfiguration.EnableFeature<SLAMonitoringFeature>();
         }
+
+        /// <summary>
+        /// Sets the update interval.
+        /// </summary>
+        /// <param name="updateInterval"></param>
+        [ObsoleteEx(Message = "This interval is no longer used for reporting. Counters values are updated as soon as they are reported", RemoveInVersion = "3.0")]
+        public void UpdateCounterEvery(TimeSpan updateInterval)
+        {
+        }
     }
 }


### PR DESCRIPTION
This PR addresses #24 by adding an empty method that is obsoleted and ready to be removed in version 3.0

API was removed in here https://github.com/Particular/NServiceBus.Metrics.PerformanceCounters/blob/00d6271b8bf7f35f3d2dd04dfb2615ea4e8db6e8/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.approved.cs without a proper obsolete. This PR changes it