### PR TITLE
Master to develop

### DIFF
--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/IntegrationTests.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/IntegrationTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 [TestFixture]
 public class IntegrationTests
 {
+    const string EndpointName = "PerfCountersIntegrationTests";
     static ManualResetEvent ManualResetEvent = new ManualResetEvent(false);
 
     [Test]
@@ -15,8 +16,7 @@ public class IntegrationTests
     {
         string message = null;
 
-        var endpointName = "PerfCountersIntegrationTests";
-        var endpointConfiguration = EndpointConfigBuilder.BuildEndpoint(endpointName);
+        var endpointConfiguration = EndpointConfigBuilder.BuildEndpoint(EndpointName);
         endpointConfiguration.DefineCriticalErrorAction(
             context =>
             {
@@ -40,13 +40,13 @@ public class IntegrationTests
         await endpoint.Stop()
             .ConfigureAwait(false);
 
-        var criticalTimePerfCounter = new PerformanceCounter("NServiceBus", PerformanceCountersFeature.CriticalTimeCounterName, endpointName, true);
-        //var processingTimePerfCounter = new PerformanceCounter("NServiceBus", PerformanceCountersFeature.ProcessingTimeCounterName, endpointName, true);
-        var slaPerCounter = new PerformanceCounter("NServiceBus", SLAMonitoringFeature.CounterName, endpointName, true);
-        var messagesFailuresPerSecondCounter = new PerformanceCounter("NServiceBus", PerformanceCountersFeature.MessagesFailuresPerSecondCounterName, endpointName, true);
-        var messagesProcessedPerSecondCounter = new PerformanceCounter("NServiceBus", PerformanceCountersFeature.MessagesProcessedPerSecondCounterName, endpointName, true);
-        var messagesPulledPerSecondCounter = new PerformanceCounter("NServiceBus", PerformanceCountersFeature.MessagesPulledPerSecondCounterName, endpointName, true);
-        Assert.AreNotEqual(0, criticalTimePerfCounter.RawValue);
+        var criticalTimePerfCounter = GetCounter(PerformanceCountersFeature.CriticalTimeCounterName);
+        var processingTimePerfCounter = GetCounter(PerformanceCountersFeature.ProcessingTimeCounterName);
+        var slaPerCounter = GetCounter(SLAMonitoringFeature.CounterName);
+        var messagesFailuresPerSecondCounter = GetCounter(PerformanceCountersFeature.MessagesFailuresPerSecondCounterName);
+        var messagesProcessedPerSecondCounter = GetCounter(PerformanceCountersFeature.MessagesProcessedPerSecondCounterName);
+        var messagesPulledPerSecondCounter = GetCounter(PerformanceCountersFeature.MessagesPulledPerSecondCounterName);
+        //Assert.AreNotEqual(0, criticalTimePerfCounter.RawValue);
         //Assert.AreNotEqual(0, processingTimePerfCounter.RawValue);
         Assert.AreNotEqual(0, slaPerCounter.RawValue);
         Assert.AreEqual(0, messagesFailuresPerSecondCounter.RawValue);
@@ -55,6 +55,8 @@ public class IntegrationTests
 
         Assert.IsNull(message);
     }
+
+    static PerformanceCounter GetCounter(string counterName) => new PerformanceCounter("NServiceBus", counterName, EndpointName, true);
 
     public class MyHandler : IHandleMessages<MyMessage>
     {

--- a/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCounterUpdater.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCounterUpdater.cs
@@ -48,7 +48,7 @@ class PerformanceCounterUpdater
             {
                 var key = new CounterInstanceName(durationProbe.Name, endpointName);
                 var performanceCounterInstance = cache.Get(key);
-                expirable[key] = performanceCounterInstance;
+                resettable[key] = performanceCounterInstance;
                 durationProbe.Register((ref DurationEvent d) => performanceCounterInstance.RawValue = (long) d.Duration.TotalSeconds);
             }
 
@@ -66,7 +66,7 @@ class PerformanceCounterUpdater
 
     readonly PerformanceCountersCache cache;
     readonly Dictionary<string, CounterInstanceName?> legacyInstanceNameMap;
-    readonly ConcurrentDictionary<CounterInstanceName, IPerformanceCounterInstance> expirable = new ConcurrentDictionary<CounterInstanceName, IPerformanceCounterInstance>();
+    readonly ConcurrentDictionary<CounterInstanceName, IPerformanceCounterInstance> resettable = new ConcurrentDictionary<CounterInstanceName, IPerformanceCounterInstance>();
     long lastCompleted;
 
     public void OnReceivePipelineCompleted()
@@ -83,7 +83,7 @@ class PerformanceCounterUpdater
             var idleFor = NowTicks - Volatile.Read(ref lastCompleted);
             if (idleFor > resetEvery.Ticks)
             {
-                foreach (var performanceCounter in expirable)
+                foreach (var performanceCounter in resettable)
                 {
                     performanceCounter.Value.RawValue = 0;
                 }

--- a/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCounterUpdater.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCounterUpdater.cs
@@ -1,16 +1,34 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Metrics.PerformanceCounters;
 
 class PerformanceCounterUpdater
 {
-    public PerformanceCounterUpdater(PerformanceCountersCache cache, Dictionary<string, CounterInstanceName?> legacyInstanceNameMap, string endpointName)
+    public PerformanceCounterUpdater(PerformanceCountersCache cache, Dictionary<string, CounterInstanceName?> legacyInstanceNameMap, string endpointName, TimeSpan? resetTimersAfter = null)
     {
+        resetEvery = resetTimersAfter ?? TimeSpan.FromSeconds(2);
         this.legacyInstanceNameMap = legacyInstanceNameMap;
         this.endpointName = endpointName;
         this.cache = cache;
+        cancellation = new CancellationTokenSource();
+        // initialize to an armed state
+        OnReceivePipelineCompleted();
+    }
+
+    public void Start()
+    {
+        cleaner = Task.Run(Cleanup);
+    }
+
+    public Task Stop()
+    {
+        cancellation.Cancel();
+        return cleaner;
     }
 
     public void Observe(ProbeContext context)
@@ -28,7 +46,9 @@ class PerformanceCounterUpdater
         {
             if (durationProbe.Name == CounterNameConventions.ProcessingTime || durationProbe.Name == CounterNameConventions.CriticalTime)
             {
-                var performanceCounterInstance = cache.Get(new CounterInstanceName(durationProbe.Name, endpointName));
+                var key = new CounterInstanceName(durationProbe.Name, endpointName);
+                var performanceCounterInstance = cache.Get(key);
+                expirable[key] = performanceCounterInstance;
                 durationProbe.Register((ref DurationEvent d) => performanceCounterInstance.RawValue = (long) d.Duration.TotalSeconds);
             }
 
@@ -46,5 +66,34 @@ class PerformanceCounterUpdater
 
     readonly PerformanceCountersCache cache;
     readonly Dictionary<string, CounterInstanceName?> legacyInstanceNameMap;
+    readonly ConcurrentDictionary<CounterInstanceName, IPerformanceCounterInstance> expirable = new ConcurrentDictionary<CounterInstanceName, IPerformanceCounterInstance>();
+    long lastCompleted;
+
+    public void OnReceivePipelineCompleted()
+    {
+        Volatile.Write(ref lastCompleted, NowTicks);
+    }
+
+    async Task Cleanup()
+    {
+        while (cancellation.IsCancellationRequested == false)
+        {
+            await Task.Delay(resetEvery).ConfigureAwait(false);
+
+            var idleFor = NowTicks - Volatile.Read(ref lastCompleted);
+            if (idleFor > resetEvery.Ticks)
+            {
+                foreach (var performanceCounter in expirable)
+                {
+                    performanceCounter.Value.RawValue = 0;
+                }
+            }
+        }
+    }
+
+    static long NowTicks => DateTime.UtcNow.Ticks;
+    readonly TimeSpan resetEvery;
     readonly string endpointName;
+    Task cleaner;
+    readonly CancellationTokenSource cancellation;
 }

--- a/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersFeature.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersFeature.cs
@@ -30,6 +30,12 @@ class PerformanceCountersFeature : Feature
 
         context.RegisterStartupTask(new Cleanup(this));
 
+        context.Pipeline.OnReceivePipelineCompleted(_=>
+        {
+            updater.OnReceivePipelineCompleted();
+            return TaskExtensions.CompletedTask;
+        });
+
         options.RegisterObservers(probeContext =>
         {
             updater.Observe(probeContext);
@@ -61,12 +67,13 @@ class PerformanceCountersFeature : Feature
 
         protected override Task OnStart(IMessageSession session)
         {
+            feature.updater.Start();
             return TaskExtensions.CompletedTask;
         }
 
         protected override Task OnStop(IMessageSession session)
         {
-            return TaskExtensions.CompletedTask;
+            return feature.updater.Stop();
         }
 
         PerformanceCountersFeature feature;

--- a/src/ScriptBuilder/CSharpCounterWriter.cs
+++ b/src/ScriptBuilder/CSharpCounterWriter.cs
@@ -1,0 +1,88 @@
+﻿namespace NServiceBus.Metrics.PerformanceCounters
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+
+    static class CSharpCounterWriter
+    {
+        public static void WriteCode(string scriptPath, IEnumerable<TimerDefinition> timers, IEnumerable<MeterDefinition> meters, Dictionary<string, string> legacyInstanceNameMap)
+        {
+            var outputPath = Path.Combine(scriptPath, "Counters.g.cs");
+            using (var streamWriter = File.CreateText(outputPath))
+            {
+                var stringBuilder = new StringBuilder();
+
+                var slaCounterDefinition = @"new CounterCreationData(""SLA violation countdown"", ""Seconds until the SLA for this endpoint is breached."", PerformanceCounterType.NumberOfItems32),";
+                stringBuilder.AppendLine(slaCounterDefinition.PadLeft(slaCounterDefinition.Length + 8));
+
+                foreach (var timer in timers)
+                {
+                    var timerDefinition = $@"new CounterCreationData(""{timer.Name}"", ""{timer.Description}"", PerformanceCounterType.NumberOfItems32),";
+                    stringBuilder.AppendLine(timerDefinition.PadLeft(timerDefinition.Length + 8));
+                }
+
+                foreach (var meter in meters)
+                {
+                    string instanceName;
+                    legacyInstanceNameMap.TryGetValue(meter.Name, out instanceName);
+
+                    var meterDefinition = $@"new CounterCreationData(""{instanceName ?? meter.Name}"", ""{meter.Description}"", PerformanceCounterType.RateOfCountsPerSecond32),";
+                    stringBuilder.AppendLine(meterDefinition.PadLeft(meterDefinition.Length + 8));
+                }
+
+                streamWriter.Write(Template, stringBuilder);
+            }
+        }
+
+        const string Template = @"using System;
+using System.Diagnostics;
+using System.Security;
+using System.Runtime.CompilerServices;
+
+[CompilerGenerated]
+public static class CounterCreator
+{{
+    public static void Create()
+    {{
+        var counterCreationCollection = new CounterCreationDataCollection(Counters);
+        try
+        {{
+            var categoryName = ""NServiceBus"";
+
+            if (PerformanceCounterCategory.Exists(categoryName))
+            {{
+                foreach (CounterCreationData counter in counterCreationCollection)
+                {{
+                    if (!PerformanceCounterCategory.CounterExists(counter.CounterName, categoryName))
+                    {{
+                        PerformanceCounterCategory.Delete(categoryName);
+                        break;
+                    }}
+                }}
+            }}
+
+            if (PerformanceCounterCategory.Exists(categoryName) == false)
+            {{
+                PerformanceCounterCategory.Create(
+                    categoryName: categoryName,
+                    categoryHelp: ""NServiceBus statistics"",
+                    categoryType: PerformanceCounterCategoryType.MultiInstance,
+                    counterData: counterCreationCollection);
+            }}
+
+            PerformanceCounter.CloseSharedResources();
+        }}
+        catch (Exception ex) when (ex is SecurityException || ex is UnauthorizedAccessException)
+        {{
+            throw new Exception(""Execution requires elevated permissions"", ex);
+        }}
+    }}
+
+    static CounterCreationData[] Counters = new CounterCreationData[]
+    {{
+{0}
+    }};
+}}";
+    }
+}

--- a/src/ScriptBuilder/PowerShellCounterWriter.cs
+++ b/src/ScriptBuilder/PowerShellCounterWriter.cs
@@ -1,0 +1,71 @@
+﻿namespace NServiceBus.Metrics.PerformanceCounters
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+
+    static class PowerShellCounterWriter
+    {
+        public static void WriteScript(string scriptPath, IEnumerable<TimerDefinition> timers, IEnumerable<MeterDefinition> meters, Dictionary<string, string> legacyInstanceNameMap)
+        {
+            var outputPath = Path.Combine(scriptPath, "CreateNSBPerfCounters.ps1");
+            using (var streamWriter = File.CreateText(outputPath))
+            {
+                var stringBuilder = new StringBuilder();
+
+                var slaCounterDefinition = @"New-Object System.Diagnostics.CounterCreationData ""SLA violation countdown"", ""Seconds until the SLA for this endpoint is breached."",  NumberOfItems32";
+                stringBuilder.AppendLine(slaCounterDefinition.PadLeft(slaCounterDefinition.Length + 8));
+
+                foreach (var timer in timers)
+                {
+                    var timerDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{timer.Name}"", ""{timer.Description}"",  NumberOfItems32";
+                    stringBuilder.AppendLine(timerDefinition.PadLeft(timerDefinition.Length + 8));
+                }
+
+                foreach (var meter in meters)
+                {
+                    string instanceName;
+                    legacyInstanceNameMap.TryGetValue(meter.Name, out instanceName);
+
+                    var meterDefinition = $@"New-Object System.Diagnostics.CounterCreationData ""{instanceName ?? meter.Name}"", ""{meter.Description}"",  RateOfCountsPerSecond32";
+                    stringBuilder.AppendLine(meterDefinition.PadLeft(meterDefinition.Length + 8));
+                }
+
+                streamWriter.Write(Template, stringBuilder);
+            }
+        }
+
+        const string Template = @"#requires -RunAsAdministrator
+Function InstallNSBPerfCounters {{
+    
+    $category = @{{Name=""NServiceBus""; Description=""NServiceBus statistics""}}
+    $counters = New-Object System.Diagnostics.CounterCreationDataCollection
+    $counters.AddRange(@(
+{0}
+    ))
+
+    if ([System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {{
+       foreach($counter in $counters){{
+            $exists = [System.Diagnostics.PerformanceCounterCategory]::CounterExists($counter.CounterName, $category.Name)
+            if (!$exists){{
+                Write-Host ""One or more counters are missing.The performance counter category will be recreated""
+                [System.Diagnostics.PerformanceCounterCategory]::Delete($category.Name)
+
+                break
+            }}
+        }}
+    }}
+
+    if (![System.Diagnostics.PerformanceCounterCategory]::Exists($category.Name)) {{
+        Write-Host ""Creating the performance counter category""
+        [void] [System.Diagnostics.PerformanceCounterCategory]::Create($category.Name, $category.Description, [System.Diagnostics.PerformanceCounterCategoryType]::MultiInstance, $counters)
+    }}
+    else {{
+        Write-Host ""No performance counters have to be created""
+    }}
+
+    [System.Diagnostics.PerformanceCounter]::CloseSharedResources()
+}}
+InstallNSBPerfCounters";
+    }
+}

--- a/src/ScriptBuilderTask.Tests/CSharpCodeGenerationTests.Generates.approved.cs
+++ b/src/ScriptBuilderTask.Tests/CSharpCodeGenerationTests.Generates.approved.cs
@@ -4,9 +4,9 @@ using System.Security;
 using System.Runtime.CompilerServices;
 
 [CompilerGenerated]
-public static class CounterCreator
+public static class CounterCreator 
 {
-    public static void Create()
+    public static void Create() 
     {
         var counterCreationCollection = new CounterCreationDataCollection(Counters);
         try

--- a/src/ScriptBuilderTask.Tests/CSharpCodeGenerationTests.Generates.approved.cs
+++ b/src/ScriptBuilderTask.Tests/CSharpCodeGenerationTests.Generates.approved.cs
@@ -1,12 +1,12 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Security;
 using System.Runtime.CompilerServices;
 
 [CompilerGenerated]
-public static class CounterCreator 
+public static class CounterCreator
 {
-    public static void Create() 
+    public static void Create()
     {
         var counterCreationCollection = new CounterCreationDataCollection(Counters);
         try

--- a/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
+++ b/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
@@ -1,3 +1,4 @@
+
 #requires -RunAsAdministrator
 Function InstallNSBPerfCounters {
     

--- a/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
+++ b/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.Generates.approved.ps1
@@ -1,4 +1,3 @@
-
 #requires -RunAsAdministrator
 Function InstallNSBPerfCounters {
     

--- a/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.cs
+++ b/src/ScriptBuilderTask.Tests/PowershellCodeGenerationTests.cs
@@ -39,6 +39,8 @@
 
             task.Execute();
 
+            GenericDiffReporter.RegisterTextFileTypes(".ps1");
+
             var powershell = Directory.EnumerateFiles(tempPath, "*.ps1", SearchOption.AllDirectories).Single();
             Approvals.VerifyFile(powershell);
         }

--- a/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
+++ b/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
@@ -8,6 +8,12 @@
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="CSharpCodeGenerationTests.Generates.approved.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="PowershellCodeGenerationTests.Generates.approved.ps1" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="ApprovalUtilities" Version="3.0.13" />
     <PackageReference Include="NServiceBus.Metrics" Version="[2.0.0, 3.0.0)" />


### PR DESCRIPTION
This PR merges back `master` to `develop` bringing back resetting counters and all the fixes we did on `1.*`. It needs to be **carefully reviewed** as it required a lot of work related to merging these two diverged streams of work.

#### Details

The merge was quite demanding. The main aspect that took a lot of time was the updater component that is now being cleaned by a separate task. It required to start a cleaning task as there's no longer `.Update` that is periodically called by the `Metrics` package.