### PR TITLE
Remove unneeded removes from ScriptBuilderTask.Tests

### DIFF
--- a/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
+++ b/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
@@ -11,12 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="CSharpCodeGenerationTests.Generates.approved.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove="PowershellCodeGenerationTests.Generates.approved.ps1" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus.Metrics" Version="2.0.0" />


### PR DESCRIPTION
The entries here seem to have been introduced after I looked at #45.

Neither of these items are needed because I already had the .cs removed from Compile, and there's no reason to remove them from None since that just hides them from Solution Explorer.