### PR TITLE
Explicit version of Metrics package targeting core 7.0-beta12

### DIFF
--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Metrics" Version="3.0.0-*" />
+    <PackageReference Include="NServiceBus.Metrics" Version="3.0.0-beta0001" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Metrics" Version="[3.0.0-*, 4.0.0)" />
+    <PackageReference Include="NServiceBus.Metrics" Version="3.0.0-beta0001" />
     <PackageReference Include="Fody" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />

--- a/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
+++ b/src/ScriptBuilderTask.Tests/ScriptBuilderTask.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NServiceBus.Metrics" Version="3.0.0-*" />
+    <PackageReference Include="NServiceBus.Metrics" Version="3.0.0-beta0001" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>


### PR DESCRIPTION
This PR explicitly attaches a beta version of Metrics package that targets core `7.0-beta12`. Metrics package had its RCs released prematurely, this is the easiest way I found to address it and to ship a beta ready version.