### PR TITLE
[WIP] Introduce support for netstandard2.0 by adding compatibility pack

### DIFF
--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/ApprovalTestConfig.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/ApprovalTestConfig.cs
@@ -1,3 +1,7 @@
 ﻿using ApprovalTests.Reporters;
 
-[assembly: UseReporter(typeof(DiffReporter),typeof(AllFailingTestsClipboardReporter))]
+#if NET452
+[assembly: UseReporter(typeof(DiffReporter), typeof(AllFailingTestsClipboardReporter))]
+#else
+[assembly: UseReporter(typeof(NUnitReporter))]
+#endif

--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
@@ -17,8 +17,9 @@
     <PackageReference Include="NUnit" Version="3.10.1" />
     <!-- requires a version that works with PublicApiGenerator (Mono.Cecil) -->
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="ApprovalTests" Version="3.0.13" />
-    <PackageReference Include="PublicApiGenerator" Version="6.4.0" />
+    <PackageReference Include="ApprovalTests" Version="3.0.13" NoWarn="NU1701" />
+    <PackageReference Include="ApprovalUtilities" Version="3.0.13" NoWarn="NU1701" />
+    <PackageReference Include="PublicApiGenerator" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters.Tests/NServiceBus.Metrics.PerformanceCounters.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
+++ b/src/NServiceBus.Metrics.PerformanceCounters/NServiceBus.Metrics.PerformanceCounters.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\binaries\</OutputPath>
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="2.0.1" />
     <PackageReference Include="NServiceBus.Metrics" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Fody" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />


### PR DESCRIPTION
This PR adds support for `netstandard2.0` by adding `Microsoft.Windows.Compatibility`.