### PR TITLE
No longer rely on settings extension to enable metrics package to remove it

### DIFF
--- a/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersExtensions.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersExtensions.cs
@@ -19,6 +19,7 @@ namespace NServiceBus
 #endif
             Guard.AgainstNull(nameof(endpointConfiguration), endpointConfiguration);
 
+            endpointConfiguration.EnableMetrics();
             endpointConfiguration.EnableFeature<PerformanceCountersFeature>();
 
             return new PerformanceCountersSettings(endpointConfiguration);

--- a/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersFeature.cs
+++ b/src/NServiceBus.Metrics.PerformanceCounters/PerformanceCountersFeature.cs
@@ -10,7 +10,7 @@ class PerformanceCountersFeature : Feature
     {
         Defaults(s =>
         {
-            options = s.EnableMetrics();
+            options = s.GetOrCreate<MetricsOptions>();
         });
     }
 


### PR DESCRIPTION
This PR removes the usage of `EnableMetrics` on the settings holder so that metrics can remove that API

Depends on https://github.com/Particular/NServiceBus.Metrics/pull/140